### PR TITLE
install libgsl-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM rocker/binder:3.4.2
 
-## Copies your repo files into the Docker Container
+
 USER root
+
+## Install system dependency for gsl package
+RUN apt-get update && apt-get -y install libgsl-dev
+
+## Copies your repo files into the Docker Container
 COPY . ${HOME}
 RUN chown -R ${NB_USER} ${HOME}
 


### PR DESCRIPTION
This should work, though clearly the average user won't know about this.  We do have some more feature-complete rocker images higher up the stack (e.g. try rocker/binder:geospatial), but people can probably always find R packages with some arcane external dependency.  But since communities often share common stacks (e.g. "geospatial"), I'm hopeful some iterations can converge on better out-of-the-box experience.